### PR TITLE
replaced rand()+$ENV concat with Session::Token

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -28,6 +28,7 @@ exclude_filename = Changes
 [Prereqs]
 perl = 5.10.0
 Mojolicious = 7.15
+Session::Token = 1.503
 
 [PkgVersion]
 

--- a/lib/Mojolicious/Plugin/AutoSecrets.pm
+++ b/lib/Mojolicious/Plugin/AutoSecrets.pm
@@ -70,8 +70,8 @@ L<Mojolicious::Plugin> and implements the following.
 =cut
 
 use Mojo::Base 'Mojolicious::Plugin';
-use Mojo::Util qw(sha1_sum);
 use Mojo::JSON qw(encode_json decode_json);
+use Session::Token;
 use Carp qw(croak);
 use Fcntl qw(:DEFAULT :flock);
 use autodie;
@@ -137,12 +137,12 @@ sub register {
 
 =func generator
 
-The default secret generator, a SHA-1 sum of a few low-effort sources.
+The default secret generator, using Session::Token
 
 =cut
 
 sub generator {
-  sha1_sum(join '', rand(1000) x 2, $$, localtime)
+  Session::Token->new->get;
 }
 
 


### PR DESCRIPTION
Hi there!

Updated to use Session::Token which provides nice b62 encoded random strings.

The default generator had a few problems:
- rand(1000) x 2 repeated the same stringified rand() output
- $$ and localtime does not provide any meaningful enthropy
